### PR TITLE
Adapt landing page for lawyers

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     />
     <meta
       name="description"
-      content="Aprende IA desde cero y automatiza procesos legales con herramientas open source"
+      content="Aprende IA desde cero hasta alcanzar un nivel experto y automatiza procesos legales con herramientas open source"
     />
 
     <!-- Open Graph / Facebook -->
@@ -38,7 +38,7 @@
     />
     <meta
       property="og:description"
-      content="Aprende IA desde cero y automatiza procesos legales con herramientas open source"
+      content="Aprende IA desde cero hasta alcanzar un nivel experto y automatiza procesos legales con herramientas open source"
     />
     <meta
       property="og:image"
@@ -61,7 +61,7 @@
     />
     <meta
       name="twitter:description"
-      content="Aprende IA desde cero y automatiza procesos legales con herramientas open source"
+      content="Aprende IA desde cero hasta alcanzar un nivel experto y automatiza procesos legales con herramientas open source"
     />
     <meta
       name="twitter:image"

--- a/src/components/Hero.vue
+++ b/src/components/Hero.vue
@@ -33,6 +33,7 @@ import { ArrowRight } from "lucide-vue-next";
               >Inteligencia Artificial
             </span>
             para abogados
+            <span class="block">de cero a experto</span>
           </h1>
         </div>
 

--- a/src/components/Pricing.vue
+++ b/src/components/Pricing.vue
@@ -19,7 +19,7 @@ enum PopularPlan {
 interface PlanProps {
   title: string;
   popular: PopularPlan;
-  price: number;
+  price: string;
   description: string;
   buttonText: string;
   benefitList: string[];
@@ -29,7 +29,7 @@ const plans: PlanProps[] = [
   {
     title: "Básico",
     popular: 0,
-    price: 0,
+    price: "Gratis",
     description:
       "Acceso limitado a recursos gratuitos y comunidad.",
     buttonText: "Comenzar gratis",
@@ -42,7 +42,7 @@ const plans: PlanProps[] = [
   {
     title: "Profesional",
     popular: 1,
-    price: 45,
+    price: "267K",
     description:
       "Curso completo con sesiones en vivo y tutorías.",
     buttonText: "Inscribirme",
@@ -55,7 +55,7 @@ const plans: PlanProps[] = [
   {
     title: "Empresarial",
     popular: 0,
-    price: 120,
+    price: "A convenir",
     description:
       "Formación personalizada para equipos de trabajo.",
     buttonText: "Contáctanos",
@@ -108,8 +108,7 @@ const plans: PlanProps[] = [
           <CardDescription class="pb-4">{{ description }}</CardDescription>
 
           <div>
-            <span class="text-3xl font-bold">${{ price }}</span>
-            <span class="text-muted-foreground"> /month</span>
+            <span class="text-3xl font-bold">{{ price }}</span>
           </div>
         </CardHeader>
 

--- a/src/components/Sponsors.vue
+++ b/src/components/Sponsors.vue
@@ -7,7 +7,6 @@ import {
   Vegan,
   Ghost,
   Puzzle,
-  Squirrel,
   Cookie,
 } from "lucide-vue-next";
 
@@ -21,7 +20,6 @@ const sponsors: sponsorsProps[] = [
   { icon: "vegan", name: "qdrant" },
   { icon: "ghost", name: "supabase" },
   { icon: "puzzle", name: "chatwoot" },
-  { icon: "squirrel", name: "gohighlevel" },
   { icon: "cookie", name: "redis" },
 ];
 
@@ -31,14 +29,12 @@ const iconMap: Record<
   | typeof Vegan
   | typeof Ghost
   | typeof Puzzle
-  | typeof Squirrel
   | typeof Cookie
 > = {
   crown: Crown,
   vegan: Vegan,
   ghost: Ghost,
   puzzle: Puzzle,
-  squirrel: Squirrel,
   cookie: Cookie,
 };
 </script>


### PR DESCRIPTION
## Summary
- tweak metadata for new description
- highlight the course goes from zero to expert
- show open-source tools instead of company logos
- update pricing plans with free, 267K and enterprise tiers

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d3c136538832f92e299f1c2f09c08