### PR TITLE
Move YouTube preview into contact section

### DIFF
--- a/src/components/Contact.vue
+++ b/src/components/Contact.vue
@@ -2,10 +2,12 @@
 import { Button } from "./ui/button";
 import { Card } from "./ui/card";
 import { tilt as vTilt } from "@/directives/tilt";
+import VideoPreview from "./VideoPreview.vue";
 </script>
 
 <template>
-  <section id="contact" class="container py-24 sm:py-32 flex justify-center">
+  <section id="contact" class="container py-24 sm:py-32 flex flex-col items-center gap-8">
+    <VideoPreview />
     <Card
       v-tilt
       class="bg-gray-50 relative group dark:hover:shadow-2xl dark:hover:shadow-emerald-500/[0.1] dark:bg-black dark:border-white/[0.2] border-black/[0.1] w-auto sm:w-[30rem] h-auto rounded-xl p-6 border">

--- a/src/components/VideoPreview.vue
+++ b/src/components/VideoPreview.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+const videoId = 'GJyouJYGWPg';
+</script>
+
+<template>
+  <section class="container py-12">
+    <div class="video-wrapper max-w-screen-md mx-auto">
+      <iframe
+        width="560"
+        height="315"
+        :src="'https://www.youtube.com/embed/' + videoId"
+        title="Video de YouTube"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen
+      ></iframe>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.video-wrapper {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+}
+
+.video-wrapper iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+</style>


### PR DESCRIPTION
## Summary
- remove `VideoPreview` from main layout
- place the YouTube video inside the contact section

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d9acb5fa0832faeee3811deb4f10c