### PR TITLE
Link plans to new routes

### DIFF
--- a/src/components/ElitePlan.vue
+++ b/src/components/ElitePlan.vue
@@ -2,25 +2,31 @@
   <section class="py-12 bg-gray-50 dark:bg-black">
     <div class="max-w-4xl mx-auto p-6 bg-white dark:bg-black rounded-lg shadow-lg">
       <h1 class="text-5xl font-extrabold mb-8 text-center text-primary uppercase tracking-wide">
-        Curso de IA para Abogados - Plan Gratuito
+        Curso de IA para Abogados - Plan Élite
       </h1>
+      <div class="text-center mb-6 space-y-2">
+        <p class="text-lg text-gray-700 dark:text-gray-300">
+          Formación in-house y consultoría dedicada para equipos jurídicos.
+        </p>
+      </div>
       <div class="flex flex-col md:flex-row items-center gap-8">
-        <img src="/ebook.png" alt="Plan Gratuito" class="w-full md:w-1/2 rounded-lg shadow" />
+        <img src="/bot.png" alt="Plan Élite" class="w-full md:w-1/2 rounded-lg shadow" />
         <div class="md:w-1/2 space-y-4">
           <p class="text-lg leading-relaxed text-gray-700">
-            Introducción gratuita al uso de la IA en el ámbito legal. Ideal para quienes desean conocer las bases antes de dar el siguiente paso.
+            Orientado a firmas y departamentos que buscan una integración profunda de la inteligencia artificial en sus procesos.
           </p>
           <ul class="list-disc list-inside marker:text-orange-500 text-gray-700 space-y-1">
-            <li>Acceso a fundamentos de IA para el sector legal</li>
-            <li>Material teórico de introducción</li>
-            <li>Acceso a comunidad de apoyo</li>
+            <li>Integración a medida de IA y flujos de trabajo automáticos</li>
+            <li>Acceso a actualizaciones y roadmap</li>
+            <li>Formación in-house y consultoría dedicada</li>
           </ul>
-          <router-link
-            to="/ebook-gratis"
+          <a
+            href="https://wa.me/message/22XPE3IWTKONL1"
+            target="_blank"
             class="w-full inline-block mt-4 py-3 text-center bg-gradient-to-r from-orange-500 to-orange-600 text-white font-semibold rounded-lg hover:from-orange-600 hover:to-orange-500 transition"
           >
-            Comenzar ahora
-          </router-link>
+            Contactar asesor
+          </a>
         </div>
       </div>
     </div>

--- a/src/components/Pricing.vue
+++ b/src/components/Pricing.vue
@@ -136,7 +136,16 @@ const plans: PlanProps[] = [
             class="w-full"
             as-child
           >
-            <router-link v-if="title === 'Profesional'" to="/plan-profesional">
+            <router-link
+              v-if="title === 'Profesional'"
+              to="/plan-profesional"
+            >
+              {{ buttonText }}
+            </router-link>
+            <router-link v-else-if="title === 'Básico'" to="/plan-gratuito">
+              {{ buttonText }}
+            </router-link>
+            <router-link v-else-if="title === 'Élite'" to="/elite">
               {{ buttonText }}
             </router-link>
             <a v-else href="https://wa.me/message/22XPE3IWTKONL1" target="_blank">

--- a/src/components/PrivacyPolicy.vue
+++ b/src/components/PrivacyPolicy.vue
@@ -54,6 +54,5 @@
 </template>
 
 <script setup lang="ts">
-import Footer from './Footer.vue';
 // Componente estático: no se requieren datos ni lógica adicional
 </script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router';
 import FreePlan from '../components/FreePlan.vue';
 import ProfessionalPlan from '../components/ProfessionalPlan.vue';
+import ElitePlan from '../components/ElitePlan.vue';
 import EbookForm from '../components/EbookForm.vue';
 import PrivacyPolicy from '../components/PrivacyPolicy.vue';
 
@@ -21,6 +22,11 @@ const routes: Array<RouteRecordRaw> = [
     path: '/plan-profesional',
     name: 'ProfessionalPlan',
     component: ProfessionalPlan,
+  },
+  {
+    path: '/elite',
+    name: 'ElitePlan',
+    component: ElitePlan,
   },
   {
     path: '/ebook-gratis',


### PR DESCRIPTION
## Summary
- improve free plan page UI
- create Elite plan page
- wire up Basico and Elite buttons in pricing section
- register new /elite route
- fix unused import in privacy policy

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6884da1d586c832f8de5469a535d7f94