### PR TITLE
Fix Vercel runtime config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,14 @@
 {
+  "functions": {
+    "api/**/*.js": {
+      "runtime": "@vercel/node@3.0.7"
+    }
+  },
   "rewrites": [
+    {
+      "source": "/api/(.*)",
+      "destination": "/api/$1"
+    },
     {
       "source": "/(.*)",
       "destination": "/index.html"
@@ -23,13 +32,5 @@
         }
       ]
     }
-  ],
-  "functions": {
-    "api/wompi/generate-signature.js": {
-      "runtime": "nodejs18.x"
-    },
-    "api/coupons/validate.js": {
-      "runtime": "nodejs18.x"
-    }
-  }
+  ]
 }


### PR DESCRIPTION
## Summary
- update `vercel.json` to use `@vercel/node@3.0.7`
- ensure rewrites and headers are preserved

## Testing
- `npm run build`
- `node pre-build-check.js` *(fails: require not defined in ES module scope)*
- `node verify-deployment.js` *(fails: require not defined in ES module scope)*
- `npm run test:api` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6889ab8c6ea8832f8189dc5a4850a720