### PR TITLE
Fix fallback alias for professional plan

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -20,6 +20,10 @@ const routes: Array<RouteRecordRaw> = [
     component: FreePlan,
   },
   {
+    path: '/plan-profesiional',
+    redirect: '/plan-profesional',
+  },
+  {
     path: '/plan-profesional',
     name: 'ProfessionalPlan',
     component: ProfessionalPlan,


### PR DESCRIPTION
## Summary
- redirect the typo route `/plan-profesiional` to the real route

## Testing
- `NODE_ENV=production npm run test:api` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_688add140c04832f8a94234c12d54a65